### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,54 +1,41 @@
 {
   "name": "grunt-xjade",
-
   "description": "Compile XJade templates with grunt.",
-
   "version": "0.1.7",
-
   "homepage": "https://github.com/dorny/grunt-xjade",
-
   "author": {
     "name": "Michal Dorner",
     "email": "dorner.michal@gmail.com"
   },
-
   "files": [
     "tasks",
     "LICENSE.txt",
     "README.md",
     "package.json"
   ],
-
   "repository": {
     "type": "git",
     "url": "git://github.com/dorny/grunt-xjade.git"
   },
-
   "bugs": {
     "url": "https://github.com/dorny/grunt-xjade/issues"
   },
-
   "license": "MIT",
-
   "scripts": {
     "test": "grunt test"
   },
-
   "dependencies": {
     "xjade": "~0.3.2"
   },
-
   "devDependencies": {
     "grunt": "~0.4.0",
     "grunt-contrib-jshint": "^0.9.2",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-nodeunit": "^0.3.3"
   },
-
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": ">=0.4.0"
   },
-
   "keywords": [
     "gruntplugin",
     "xjade"


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0


Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
